### PR TITLE
:zap: fix make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 d/up:
-	@docker-compose up -d --build
-	open http://localhost:8001/
-	echo see src on front/index.js!
+	@docker-compose up -d --build && \
+	open http://localhost:8001/ && \
+	echo see src on front/index.js! && \
 	echo type 'make d/down' to stop this docker
 
 d/down:


### PR DESCRIPTION
```
d/up:
  @docker-compose up -d --build
  open http://localhost:8001
︙
```
は擬似的に並列に処理されます。composeが建ってからopenするのが適切と考えました。
